### PR TITLE
allow for main branch as default TCUE-3654

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ with:
   snapshot: true
 ```
 
+### default_branch
+Use `default_branch` when you want to use a different branch than `master` or `main` as the default branch.
+
+```yaml
+with:
+  name: myDocker/repository
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+  default_branch: trunk
+```
+
 ### dockerfile
 Use `dockerfile` when you would like to explicitly build a Dockerfile.  
 This might be useful when you have multiple DockerImages.  

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   snapshot:
     description: 'Use snapshot to push an additional image'
     required: false
+  default_branch:
+    description: 'Set the default branch of your repository (default: master)'
+    required: false
   dockerfile:
     description: 'Use dockerfile when you would like to explicitly build a Dockerfile'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ function main() {
   DOCKERNAME="${INPUT_NAME}:${TAG}"
 
   # check if we should do anything at all with this branch
-  if { [ -z ${PUSH_BRANCH_TO_DOCKERHUB} ] || [ "${PUSH_BRANCH_TO_DOCKERHUB}" = "false" ]; } && [ "${TAG}" != "develop" ] && [ "${TAG}" != "develop-1.0" ] && [ "${TAG}" != "develop-2.0" ] && [ "${TAG}" != "master" ] &&  ! isReleaseBranch && ! isGitTag ; then
+  if { [ -z ${PUSH_BRANCH_TO_DOCKERHUB} ] || [ "${PUSH_BRANCH_TO_DOCKERHUB}" = "false" ]; } && [ "${TAG}" != "develop" ] && [ "${TAG}" != "develop-1.0" ] && [ "${TAG}" != "develop-2.0" ] && [ "${TAG}" != "master" ] && [ "${TAG}" != "main" ] &&  ! isReleaseBranch && ! isGitTag ; then
     echo "workflow environment PUSH_BRANCH_TO_DOCKERHUB is false or not set and this is no default branch -> stopping push gracefully -> no error"
     exit 0;
   fi
@@ -69,7 +69,7 @@ function translateDockerTag() {
   if hasCustomTag; then
     TAG=$(echo ${INPUT_NAME} | cut -d':' -f2)
     INPUT_NAME=$(echo ${INPUT_NAME} | cut -d':' -f1)
-  elif isOnMaster; then
+  elif isOnDefaultBranch; then
     TAG="latest"
   elif isGitTag && usesBoolean "${INPUT_TAG_NAMES}"; then
     TAG=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
@@ -88,8 +88,12 @@ function hasCustomTag() {
   [ $(echo "${INPUT_NAME}" | sed -e "s/://g") != "${INPUT_NAME}" ]
 }
 
-function isOnMaster() {
-  [ "${BRANCH}" = "master" ]
+isOnDefaultBranch() {
+  if uses "${INPUT_DEFAULT_BRANCH}"; then
+    [ "${BRANCH}" = "${INPUT_DEFAULT_BRANCH}" ]
+  else
+    [ "${BRANCH}" = "master" ] || [ "${BRANCH}" = "main" ]
+  fi
 }
 
 function isGitTag() {


### PR DESCRIPTION
Issue: [TCUE-3654](https://handelsblatt-gmbh.atlassian.net/browse/TCUE-3654)

This PR allows for the "default"/prod branch to be "main".

It uses snippet from https://github.com/elgohr/Publish-Docker-Github-Action/commit/b1253b2edfcd8636685eb08955d28698c6db53d2
Minus the test, dunno how to run that.

## Testing

Local testing done via [act](https://github.com/nektos/act) and within the tgs.channelizer repo.
See act readme for install and usage. I used the `medium` image during initial setup/first start.

Within the `Publish to Dockerhub` step of the `push_to_dockerhub` workflow of tgs.channelizer I changed `uses` to `urbanmedia/Publish-Docker-Github-Action@feature/TCUE-3654_allow-for-main-branch-as-default` and provided it with username and password for dockerhub, I also changed the `name` for the dockerhub repository to a new one within my own namespace, just to be safe.

Then I ran `act` while in the develop branch. A `develop` image appeared on docker hub.

I then switched to the main branch, merged develop into it and applied the same changes to the `push_to_dockerhub` workflow as before. Then I manually tagged main with `1.0.0`.
I ran act again and a 1.0.0 image appeared in docker hub.
